### PR TITLE
DM-31015: FTDI devices now return the telemetry correctly. The CSC no…

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,22 @@
 Version History
 ###############
 
+v0.4.1
+======
+
+* Fixed a bug for FTDI devices where data were readf correctly but not sent to the CSC.
+* Removed an `await` in a normal function (not coroutine) for RpiSerialHat devices.
+* Made sure that the CSC starts up in local mode.
+
+Requires:
+
+* ts_salobj 6.4
+* ts_idl 3.1
+* IDL file for ESS from ts_xml 9.1
+* ts_envsensors
+* ts_tcpip
+
+
 v0.4.0
 ======
 

--- a/python/lsst/ts/ess/ess_csc.py
+++ b/python/lsst/ts/ess/ess_csc.py
@@ -73,7 +73,7 @@ class EssCsc(salobj.ConfigurableCsc):
     def __init__(
         self,
         index: int,
-        local_mode: bool = False,
+        local_mode: bool = True,
         config_dir: str = None,
         initial_state: salobj.State = salobj.State.STANDBY,
         simulation_mode: int = 0,

--- a/python/lsst/ts/ess/rpi_serial_hat.py
+++ b/python/lsst/ts/ess/rpi_serial_hat.py
@@ -360,7 +360,7 @@ class RpiSerialHat:
 
         resp: str = ""
         err: str = "OK"
-        await self._rpi_pin_state(self._pin_dirn, RpiSerialHat.STATE_DIRN_RX)
+        self._rpi_pin_state(self._pin_dirn, RpiSerialHat.STATE_DIRN_RX)
         with self._lock:
             while not resp.endswith("\r\n"):
                 try:

--- a/python/lsst/ts/ess/vcp_ftdi.py
+++ b/python/lsst/ts/ess/vcp_ftdi.py
@@ -210,7 +210,9 @@ class VcpFtdi:
 
         Returns
         -------
-        error, resp : 'tuple'
+        name, error, resp : 'tuple'
+        name: 'str'
+            The name of the device
         error : 'str'
             Error string.
             'OK' = No error
@@ -247,6 +249,6 @@ class VcpFtdi:
                     len(self._terminator) > 0
                     and resp[-len(self._terminator) :] == self._terminator
                 ):
-                    return err, resp
+                    return self.name, err, resp
                 elif 0 < self._line_size <= len(resp):
-                    return err, resp
+                    return self.name, err, resp


### PR DESCRIPTION
…w starts in local mode. Minor fix for RpiSerialHat devices.